### PR TITLE
Add a unit test

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 extern crate rust8;
 
+use std::cell::RefCell;
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
+use std::rc::Rc;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -12,8 +14,8 @@ fn main() {
     let mut f = File::open(filename).expect("File not found");
     let mut buffer: Vec<u8> = Vec::new();
     f.read_to_end(&mut buffer).unwrap();
-    let mut screen = rust8::Screen::new();
-    let mut chip8 = rust8::Chip8::new(&mut screen);
+    let screen = Rc::new(RefCell::new(rust8::Screen::new()));
+    let mut chip8 = rust8::Chip8::new(Rc::clone(&screen));
     chip8.load_rom(buffer);
 
     loop {


### PR DESCRIPTION
This unit test was the first real test of the public
API, so it naturally ran into some issues larger
than the unit it was supposed to test.

  - Changed Screen from mut with lifetime to
    a Rc<RefCell<Screen>> so we can do compile
    time unsafe borrows (runtime will still panic
    if it is actually violating any rules)
  - Moved unit tests to bottom
  - Stressed out about endianess for too long

Hopefully the change to the smart pointer was
a good call. I feel it is best to avoid such things
if possible, but I can't think of a way to let two
references of Screen float around at once otherwise.
Obviously the Chip8 will have to have a mutable reference
to update the "VRAM", and a reference will have to float
around for the graphics api to access as well at the same
time. This breaks the rule of either 1 mutable reference,
or any number of immutable references at the same time at
compile time. This change circumvents that in what I believe
is a safe manner.